### PR TITLE
Remove python-dateutil requirement

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,15 +3,17 @@
 Release Notes
 -------------
 
-.. Future Release
-      ==============
-        * Enhancements
-        * Fixes
-        * Changes
-        * Documentation Changes
-        * Testing Changes
+Future Release
+==============
+    * Enhancements
+    * Fixes
+    * Changes
+        * Remove python-dateutil dependency requirement (:pr:`48`)
+    * Documentation Changes
+    * Testing Changes
 
-    .. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`rwedge`
 
 v2.0.0 Mar 14, 2022
 ===================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 featuretools>=1.0.0
 numpy>=1.13.3
 pandas>=0.23.0
-python-dateutil>=2.6.1,<2.8.1
 tqdm>=4.19.2
 graphviz>=0.8.4


### PR DESCRIPTION
This package is not use directly and the issue between dependencies has been resolved.