### PR TITLE
Release v2.0.1

### DIFF
--- a/autonormalize/__init__.py
+++ b/autonormalize/__init__.py
@@ -2,4 +2,4 @@
 from .autonormalize import *
 from .classes import Dependencies
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/autonormalize/tests/test_version.py
+++ b/autonormalize/tests/test_version.py
@@ -2,4 +2,4 @@ from autonormalize import __version__
 
 
 def test_version():
-    assert __version__ == "2.0.0"
+    assert __version__ == "2.0.1"

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,7 @@ Release Notes
 
 .. Thanks to the following people for contributing to this release:
 
-v2.1.0 Apr 25, 2022
+v2.0.1 Apr 25, 2022
 ==============
     * Changes
         * Remove python-dateutil dependency requirement (:pr:`48`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Release Notes
 .. Thanks to the following people for contributing to this release:
 
 v2.0.1 Apr 25, 2022
-==============
+===================
     * Changes
         * Remove python-dateutil dependency requirement (:pr:`48`)
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,13 +3,20 @@
 Release Notes
 -------------
 
-Future Release
-==============
+.. Future Release
+    ==============
     * Enhancements
     * Fixes
     * Changes
-        * Remove python-dateutil dependency requirement (:pr:`48`)
     * Documentation Changes
+    * Testing Changes
+
+.. Thanks to the following people for contributing to this release:
+
+v2.1.0 Apr 25, 2022
+==============
+    * Changes
+        * Remove python-dateutil dependency requirement (:pr:`48`)
     * Testing Changes
         * Add ``test_version.py`` and release notes updated CI check (:pr:`49`)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(dirname, 'README.md')) as f:
 
 setup(
     name='autonormalize',
-    version='2.0.0',
+    version='2.0.1',
     description='a library for automated table normalization',
     url='https://github.com/alteryx/autonormalize',
     license='BSD 3-clause',


### PR DESCRIPTION
v2.0.1 Apr 25, 2022
==============
    * Changes
        * Remove python-dateutil dependency requirement (#48)
    * Testing Changes
        * Add ``test_version.py`` and release notes updated CI check (#49)
